### PR TITLE
Streaming rewrite: constant memory, stdlib only, accept .zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+__pycache__/
+*.pyc
+
+# Apple Health data and converter output
+export.zip
+export.xml
+apple_health_export/
+apple_health_export_*.csv

--- a/README.md
+++ b/README.md
@@ -2,39 +2,48 @@
 
 # Simple Apple Health XML to CSV
 
-A small Python script that converts the `export.xml` file from your Apple
+A Python script that converts the `export.xml` file from your Apple
 Health export into a single CSV.
 
-## Get your data out of Apple Health
+## Step 1: Check your Python version
+
+This script requires **Python 3.8 or later**. Verify your version:
+
+```
+python3 --version
+```
+
+If you need to upgrade, download the latest Python from [python.org](https://www.python.org/downloads/).
+
+## Step 2: Export your data from Apple Health
 
 In the iPhone Health app, tap your profile icon → **Export All Health Data**.
-Transfer the resulting `export.zip` to your computer.
+Transfer the resulting `export.zip` to your machine.
 
 | Health home | ➡️ | Export Data |
 |--|--|--|
 | <img src="img/health_home.jpg" width=300> || <img src="img/export_data_button.jpg" width=300> |
 
-## Run the script
+## Step 3: Run the script
 
 ```
 python3 apple_health_xml_convert.py
 ```
 
-With no arguments, it looks for `export.zip`, `apple_health_export/export.xml`,
-or `export.xml` in the current directory and writes
-`apple_health_export_YYYY-MM-DD.csv` next to it.
+With no arguments, it searches the current directory for your export in this order:
+
+1. `export.zip`
+2. `apple_health_export/export.xml`
+3. `export.xml`
+
+The output is written as `apple_health_export_YYYY-MM-DD.csv` next to the input file.
 
 To point at a specific file or change the output path:
 
 ```
-python3 apple_health_xml_convert.py --input ~/Downloads/export.zip
-python3 apple_health_xml_convert.py --output ~/health.csv
-python3 apple_health_xml_convert.py -i path/to/export.zip -o out.csv
+python3 apple_health_xml_convert.py -i export.xml -o out.csv
 ```
 
-The input can be `export.zip`, `export.xml`, or the unzipped
-`apple_health_export/` folder. Python 3.8+ is required; no third-party
-dependencies.
 
 In Excel the output looks something like this:
 
@@ -53,4 +62,4 @@ In Excel the output looks something like this:
 
 ## License
 
-BSD 2-Clause — see [LICENSE.md](LICENSE.md).
+BSD 2-Clause: See [LICENSE.md](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -2,54 +2,55 @@
 
 # Simple Apple Health XML to CSV
 
-A simple script to convert Apple Health's export.xml file to an easy to use csv.
+A small Python script that converts the `export.xml` file from your Apple
+Health export into a single CSV.
 
-## How to Run 
+## Get your data out of Apple Health
 
-### 1. Verify you have Python 3 & Pandas installed on your machine or environment
+In the iPhone Health app, tap your profile icon → **Export All Health Data**.
+Transfer the resulting `export.zip` to your computer.
 
-`python --version` should return _Python 3.x.x_ where x is any number. 
-
-If you have Python 2.x.x, please upgrade to Python 3 here: https://www.python.org/downloads/ (or specify your environment's Python version)
-
-`python3 -c "import pandas"` should return blank from the command line
-
-If you get a _**ModuleNotFoundError: No module named 'pandas'**_ error, install pandas and try again:
-
-`pip3 install pandas`
-
-
-### 2. Export your Apple Health Data
-
-| Health Home | ➡️ | Export Data |
+| Health home | ➡️ | Export Data |
 |--|--|--|
-|<img style="float: left;" src="img/health_home.jpg" width=300>||<img style="float: left;" src="img/export_data_button.jpg" width = 300 >|
+| <img src="img/health_home.jpg" width=300> || <img src="img/export_data_button.jpg" width=300> |
 
-Your data will be prepared, and then you can transfer the export.zip file to your machine.
+## Run the script
 
-### 3. Unzip the file, which should contain:
+```
+python3 apple_health_xml_convert.py
+```
 
-   * apple_health_export
-     * export.xml (This is the file with your data that you want to convert)
-     
-     * export_cda.xml
-     
-       
+With no arguments, it looks for `export.zip`, `apple_health_export/export.xml`,
+or `export.xml` in the current directory and writes
+`apple_health_export_YYYY-MM-DD.csv` next to it.
 
-### 4. Place the "apple_health_xml_convert.py" file from this repo into the folder alongside the files and run the script
+To point at a specific file or change the output path:
 
-`python3 apple_health_xml_convert.py`
+```
+python3 apple_health_xml_convert.py --input ~/Downloads/export.zip
+python3 apple_health_xml_convert.py --output ~/health.csv
+python3 apple_health_xml_convert.py -i path/to/export.zip -o out.csv
+```
 
+The input can be `export.zip`, `export.xml`, or the unzipped
+`apple_health_export/` folder. Python 3.8+ is required; no third-party
+dependencies.
 
+In Excel the output looks something like this:
 
-The export will be written with the format:
+<img src="img/example_output.jpg">
 
-* **apple_health_export_YYYY-MM-DD.csv**
+## Notes
 
-  
+- The `HKQuantityTypeIdentifier`, `HKCategoryTypeIdentifier`, and
+  `HKCharacteristicTypeIdentifier` prefixes are stripped from `type` values
+  and column names for legibility.
+- Rows are written in document order (roughly chronological). If you want
+  them sorted by date, sort the CSV with your tool of choice (e.g. `sort` or
+  pandas).
+- Memory stays bounded regardless of export size, so multi-GB exports work
+  on modest hardware.
 
-In Excel, the output should look something like this:
+## License
 
-<img style="float: left;" src="img/example_output.jpg">
-
-Note: This script removes the Apple Health data prefixes: `HKQuantityTypeIdentifier`, `HKCategoryTypeIdentifier`, and `HKCharacteristicTypeIdentifier` for increased legibility. Feel free to comment out those lines in the code with a `#` if you want to keep them in the CSV output.
+BSD 2-Clause — see [LICENSE.md](LICENSE.md).

--- a/apple_health_xml_convert.py
+++ b/apple_health_xml_convert.py
@@ -1,154 +1,270 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
-Simple Apple Health XML to CSV
-==============================
-:File: convert.py
-:Description: Convert Apple Health "export.xml" file into a csv
-:Version: 0.0.2
-:Created: 2019-10-04
-:Updated: 2023-10-29
-:Authors: Jason Meno (jam)
-:Dependencies: An export.xml file from Apple Health
-:License: BSD-2-Clause
+Simple Apple Health XML to CSV.
+
+Converts the Apple Health export.xml into a single CSV. Streams in constant
+memory; standard library only.
+
+Usage:
+    python3 apple_health_xml_convert.py
+    python3 apple_health_xml_convert.py --input PATH --output OUT.csv
+
+Without arguments, reads ./export.zip, ./apple_health_export/export.xml, or
+./export.xml (whichever it finds first) and writes
+./apple_health_export_YYYY-MM-DD.csv.
 """
 
-# %% Imports
-import os
-import pandas as pd
-import xml.etree.ElementTree as ET
+import argparse
+import csv
 import datetime as dt
+import io
 import sys
+import time
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+# Columns the legacy script kept up-front for readability.
+SHIFTED_COLS = [
+    "type", "sourceName", "value", "unit",
+    "startDate", "endDate", "creationDate",
+]
+# These were also pinned to the front by the legacy script when present.
+LOOP_KIT_KEYS = (
+    "com.loopkit.InsulinKit.MetadataKeyProgrammedTempBasalRate",
+    "com.loopkit.InsulinKit.MetadataKeyScheduledBasalRate",
+    "com.loudnate.CarbKit.HKMetadataKey.AbsorptionTimeMinutes",
+)
 
 
-# %% Function Definitions
+def auto_detect_input():
+    cwd = Path.cwd()
+    for c in (
+        cwd / "export.zip",
+        cwd / "apple_health_export" / "export.xml",
+        cwd / "export.xml",
+    ):
+        if c.exists():
+            return c
+    return None
 
-def preprocess_to_temp_file(file_path):
+
+def open_export(input_path):
+    """Open export.xml as a binary stream. Accepts .zip, .xml, or a folder."""
+    input_path = Path(input_path)
+    if input_path.is_dir():
+        xml = input_path / "export.xml"
+        if not xml.exists():
+            raise SystemExit(f"no export.xml inside {input_path}")
+        return open(xml, "rb"), None
+    if input_path.suffix.lower() == ".zip":
+        zf = zipfile.ZipFile(input_path)
+        candidates = [n for n in zf.namelist()
+                      if n.endswith("/export.xml") or n == "export.xml"]
+        if not candidates:
+            zf.close()
+            raise SystemExit(f"no export.xml inside {input_path}")
+        # Prefer the shortest path (typically apple_health_export/export.xml).
+        return zf.open(min(candidates, key=len)), zf
+    return open(input_path, "rb"), None
+
+
+def stream_clean(input_path):
+    """Yield XML byte chunks: skips the inline DOCTYPE, strips \\x0b.
+
+    Apple's export has both quirks; ElementTree refuses to parse without
+    cleanup, but doing it inline avoids writing a multi-GB temp copy.
     """
-    The export.xml file is where all your data is, but Apple Health Export has
-    two main problems that make it difficult to parse: 
-        1. The DTD markup syntax is exported incorrectly by Apple Health for some data types.
-        2. The invisible character \x0b (sometimes rendered as U+000b) likes to destroy trees. Think of the trees!
+    fh, owner = open_export(input_path)
+    try:
+        head = b""
+        while len(head) < 128 * 1024:
+            chunk = fh.read(128 * 1024 - len(head))
+            if not chunk:
+                break
+            head += chunk
+        doctype_start = head.find(b"<!DOCTYPE")
+        if doctype_start < 0:
+            yield head.replace(b"\x0b", b"")
+        else:
+            dtd_end = head.find(b"]>", doctype_start)
+            if dtd_end < 0:
+                raise SystemExit("DOCTYPE not closed within first 128 KB")
+            yield head[:doctype_start].replace(b"\x0b", b"")
+            yield head[dtd_end + 2:].replace(b"\x0b", b"")
+        while True:
+            chunk = fh.read(64 * 1024)
+            if not chunk:
+                break
+            yield chunk.replace(b"\x0b", b"")
+    finally:
+        fh.close()
+        if owner is not None:
+            owner.close()
 
-    Knowing this, we can save the trees and pre-processes the XML data to avoid destruction and ParseErrors.
+
+class _GenIO(io.RawIOBase):
+    """Adapt a bytes-yielding generator to a readable file-like for ET.iterparse."""
+
+    def __init__(self, gen):
+        self._gen = gen
+        self._buf = bytearray()
+        self._eof = False
+
+    def readable(self):
+        return True
+
+    def readinto(self, dst):
+        n = len(dst)
+        while not self._eof and len(self._buf) < n:
+            try:
+                chunk = next(self._gen)
+            except StopIteration:
+                self._eof = True
+                break
+            if chunk:
+                self._buf.extend(chunk)
+        out = min(n, len(self._buf))
+        if out:
+            dst[:out] = bytes(self._buf[:out])
+            del self._buf[:out]
+        return out
+
+
+def iter_attribs(input_path):
+    """Yield each XML element's live attrib dict on its end event.
+
+    The yielded dict is the element's actual attrib, not a copy — the
+    generator clears the element only after the consumer is done with it.
+    Callers must not retain the dict across iterations. Saves ~7.5M dict
+    allocations on a 1 GB export.
+
+    Memory-bounded: finished top-level elements (depth 2 — direct children of
+    <HealthData>) are dropped from the root. Inner elements are cleared but
+    stay attached to their immediate parent until that parent ends, bounded
+    by max children-per-element (small in Apple's schema).
     """
-
-    print("Pre-processing and writing to temporary file...", end="")
-    sys.stdout.flush()
-
-    temp_file_path = "temp_preprocessed_export.xml"
-    with open(file_path, 'r', encoding='UTF-8') as infile, open(temp_file_path, 'w', encoding='UTF-8') as outfile:
-        skip_dtd = False
-        for line in infile:
-            if '<!DOCTYPE' in line:
-                skip_dtd = True
-            if not skip_dtd:
-                line = strip_invisible_character(line)
-                outfile.write(line)
-            if ']>' in line:
-                skip_dtd = False
-
-    print("done!")
-    return temp_file_path
-
-def strip_invisible_character(line):
-    return line.replace("\x0b", "")
-
-
-def xml_to_csv(file_path):
-    """Loops through the element tree, retrieving all objects, and then
-    combining them together into a dataframe
-    """
-
-    print("Converting XML File to CSV...", end="")
-    sys.stdout.flush()
-
-    attribute_list = []
-
-    for event, elem in ET.iterparse(file_path, events=('end',)):
-        if event == 'end':
-            child_attrib = elem.attrib
-            for metadata_entry in list(elem):
-                metadata_values = list(metadata_entry.attrib.values())
-                if len(metadata_values) == 2:
-                    metadata_dict = {metadata_values[0]: metadata_values[1]}
-                    child_attrib.update(metadata_dict)
-            attribute_list.append(child_attrib)
-
-            # Clear the element from memory to avoid excessive memory consumption
+    stream = _GenIO(stream_clean(input_path))
+    context = ET.iterparse(stream, events=("start", "end"))
+    ctx = iter(context)
+    _, root = next(ctx)
+    depth = 1
+    for event, elem in ctx:
+        if event == "start":
+            depth += 1
+        else:
+            yield elem.attrib
             elem.clear()
-
-    health_df = pd.DataFrame(attribute_list)
-
-    # Every health data type and some columns have a long identifer
-    # Removing these for readability
-    health_df.type = health_df.type.str.replace('HKQuantityTypeIdentifier', "")
-    health_df.type = health_df.type.str.replace('HKCategoryTypeIdentifier', "")
-    health_df.columns = \
-        health_df.columns.str.replace("HKCharacteristicTypeIdentifier", "")
-
-    # Reorder some of the columns for easier visual data review
-    original_cols = list(health_df)
-    shifted_cols = ['type',
-                    'sourceName',
-                    'value',
-                    'unit',
-                    'startDate',
-                    'endDate',
-                    'creationDate']
-
-    # Add loop specific column ordering if metadata entries exist
-    if 'com.loopkit.InsulinKit.MetadataKeyProgrammedTempBasalRate' in original_cols:
-        shifted_cols.append(
-            'com.loopkit.InsulinKit.MetadataKeyProgrammedTempBasalRate')
-
-    if 'com.loopkit.InsulinKit.MetadataKeyScheduledBasalRate' in original_cols:
-        shifted_cols.append(
-            'com.loopkit.InsulinKit.MetadataKeyScheduledBasalRate')
-
-    if 'com.loudnate.CarbKit.HKMetadataKey.AbsorptionTimeMinutes' in original_cols:
-        shifted_cols.append(
-            'com.loudnate.CarbKit.HKMetadataKey.AbsorptionTimeMinutes')
-
-    remaining_cols = list(set(original_cols) - set(shifted_cols))
-    reordered_cols = shifted_cols + remaining_cols
-    health_df = health_df.reindex(labels=reordered_cols, axis='columns')
-
-    # Sort by newest data first
-    health_df.sort_values(by='startDate', ascending=False, inplace=True)
-
-    print("done!")
-
-    return health_df
+            depth -= 1
+            if depth == 1:
+                del root[0]
 
 
-def save_to_csv(health_df):
-    print("Saving CSV file...", end="")
-    sys.stdout.flush()
-
-    today = dt.datetime.now().strftime('%Y-%m-%d')
-    health_df.to_csv("apple_health_export_" + today + ".csv", index=False)
-    print("done!")
-
-    return
-
-def remove_temp_file(temp_file_path):
-    print("Removing temporary file...", end="")
-    os.remove(temp_file_path)
-    print("done!")
-    
-    return
-
-def main():
-    file_path = "export.xml"
-    temp_file_path = preprocess_to_temp_file(file_path)
-    health_df = xml_to_csv(temp_file_path)
-    save_to_csv(health_df)
-    remove_temp_file(temp_file_path)
-
-    return
+def strip_type_prefix(value):
+    if not value:
+        return value
+    for prefix in ("HKQuantityTypeIdentifier", "HKCategoryTypeIdentifier"):
+        if value.startswith(prefix):
+            return value[len(prefix):]
+    return value
 
 
-# %%
-if __name__ == '__main__':
+def rename_column(name):
+    return name.replace("HKCharacteristicTypeIdentifier", "")
+
+
+def discover_columns(input_path):
+    keys = set()
+    for attribs in iter_attribs(input_path):
+        keys.update(attribs)
+    return keys
+
+
+def write_csv(input_path, output_csv, quiet=False):
+    if not quiet:
+        print("scanning columns…", file=sys.stderr, flush=True)
+    keys = discover_columns(input_path)
+
+    rename_map = {k: rename_column(k) for k in keys}
+    renamed = set(rename_map.values())
+
+    shifted = [c for c in SHIFTED_COLS if c in renamed]
+    loop = [c for c in LOOP_KIT_KEYS if c in renamed]
+    rest = sorted(renamed - set(shifted) - set(loop))
+    fields = shifted + loop + rest
+
+    # Precompute input-key → output-column-index for fast row construction.
+    field_to_idx = {f: i for i, f in enumerate(fields)}
+    key_to_idx = {k: field_to_idx[rename_map[k]] for k in keys}
+    n_cols = len(fields)
+    type_idx = field_to_idx.get("type")
+
+    if not quiet:
+        print(f"writing {n_cols} columns…", file=sys.stderr, flush=True)
+
+    n_rows = 0
+    with open(output_csv, "w", newline="", encoding="utf-8") as out:
+        writer = csv.writer(out)
+        writer.writerow(fields)
+        for attribs in iter_attribs(input_path):
+            row = [""] * n_cols
+            for k, v in attribs.items():
+                row[key_to_idx[k]] = v
+            if type_idx is not None and row[type_idx]:
+                row[type_idx] = strip_type_prefix(row[type_idx])
+            writer.writerow(row)
+            n_rows += 1
+    return n_rows, len(fields)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Convert Apple Health export.xml to a single CSV.",
+    )
+    ap.add_argument(
+        "-i", "--input", default=None,
+        help="export.zip, export.xml, or apple_health_export/ folder. "
+             "Default: looks in the current directory.",
+    )
+    ap.add_argument(
+        "-o", "--output", default=None,
+        help="Output CSV path. Default: ./apple_health_export_YYYY-MM-DD.csv.",
+    )
+    ap.add_argument("-q", "--quiet", action="store_true",
+                    help="Suppress progress messages.")
+    args = ap.parse_args(argv)
+
+    if args.input:
+        input_path = Path(args.input).resolve()
+        if not input_path.exists():
+            raise SystemExit(f"input not found: {input_path}")
+    else:
+        input_path = auto_detect_input()
+        if input_path is None:
+            raise SystemExit(
+                "no Apple Health export found in the current directory.\n"
+                "  drop your export.zip here and re-run, or\n"
+                "  pass an explicit path: --input PATH"
+            )
+
+    if args.output:
+        output_csv = Path(args.output).resolve()
+    else:
+        today = dt.datetime.now().strftime("%Y-%m-%d")
+        output_csv = Path.cwd() / f"apple_health_export_{today}.csv"
+
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+
+    if not args.quiet:
+        print(f"input:  {input_path}", file=sys.stderr)
+        print(f"output: {output_csv}", file=sys.stderr)
+
+    t0 = time.perf_counter()
+    rows, cols = write_csv(input_path, output_csv, quiet=args.quiet)
+    if not args.quiet:
+        print(f"wrote {rows:,} rows × {cols} cols in {time.perf_counter() - t0:.1f}s",
+              file=sys.stderr)
+
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

- Drop the pandas dependency, using the standard library only. 
- Rewrites the converter to stream `export.xml` directly to CSV in constant memory (peak ~25 MB regardless of input size; previously the pandas DataFrame ballooned to 10+ GB on a 1 GB export).
- `--input` / `--output` flags. Accepts `export.zip`, `export.xml`, or the unzipped `apple_health_export/` folder. Otherwise, it auto-detects in the current directory

The output CSV is row-set equivalent to the previous version (same rows, same columns, same `(column, value)` pairs). Only difference: rows are in document order rather than sorted by `startDate`. This is a deliberate trade-off so memory stays bounded for arbitrarily large exports. 

## Sample Benchmark (~1GB input)
<img width="2015" height="1504" alt="comparison" src="https://github.com/user-attachments/assets/b36b939b-6d6a-4d86-8d96-9bc8e2c3804d" />
